### PR TITLE
Updated props.conf settings to improve proper ingestion by Splunk

### DIFF
--- a/sigsci_TA_for_splunk/default/props.conf
+++ b/sigsci_TA_for_splunk/default/props.conf
@@ -1,15 +1,20 @@
 [sigsci-events]
-KV_MODE = json
-LEARN_MODEL = 1
-SHOULD_LINEMERGE = 0
-category = Splunk App Add-on Builder
-pulldown_type = 1
+SHOULD_LINEMERGE=FALSE
+NO_BINARY_CHECK=true
+INDEXED_EXTRACTIONS=json
+KV_MODE=none
+TIMESTAMP_FIELDS=created
+TZ=UTC
+TIME_FORMAT = %Y-%m-%dT%H:%M:%SZ
+LINE_BREAKER=([\r\n]+)\{\"created\"
+
 
 [sigsci-request]
-KV_MODE = json
-LEARN_MODEL = 1
-MAX_TIMESTAMP_LOOKAHEAD = 512
-SHOULD_LINEMERGE = 0
+SHOULD_LINEMERGE=FALSE
+CHARSET=UTF-8
+INDEXED_EXTRACTIONS=json
+KV_MODE=none
+TIMESTAMP_FIELDS=timestamp
 TIME_FORMAT = %Y-%m-%dT%H:%M:%S.%fZ
-category = Splunk App Add-on Builder
-pulldown_type = 1
+LINE_BREAKER=([\r\n]+)\{
+


### PR DESCRIPTION
With the prior config, splunk often guessed the incorrect timestamp.  This way, splunk should run more efficiently (With no guessing), and Sigsci data will be ingested as expected.

Also.. SHOULD_LINEMERGE =0 (is incorrect.. it is TRUE|FALSE.. and really should never be true if one provides a LINE_BREAKER setting, which one should always do.  When we let machines guess, they take over our world become repairmen :)

Note.. you'll need to resubmit this for app cert (I think)